### PR TITLE
feature: return status labels (TCS-33)

### DIFF
--- a/lib/shared/widgets/order_confirmation_view.dart
+++ b/lib/shared/widgets/order_confirmation_view.dart
@@ -1,26 +1,227 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 class OrderConfirmationView extends StatelessWidget {
-  const OrderConfirmationView({super.key});
+  const OrderConfirmationView({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // TODO: Start replacing content from here
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: const [
-        Padding(
-          padding: EdgeInsets.only(top: 26.0),
+    return Container();
+  }
+}
+
+class PickupLabel extends StatelessWidget {
+  const PickupLabel({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildLabel(
+      title: "Return Pickup Scheduled",
+      titleStyle: const TextStyle(
+        color: Colors.white,
+        fontSize: 18,
+        fontWeight: FontWeight.w500,
+      ),
+      subtitle: Row(
+        children: const [
+          Text(
+            "Expected Pickup Date",
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          SizedBox(width: 8),
+          Icon(CupertinoIcons.calendar, color: Colors.white, size: 18),
+          SizedBox(width: 4),
+          Text(
+            "Thu Jan 30",
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 17,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+      description:
+          "A driver will come to pick up your return item from your provided address. Please ensure the item is securely packed and ready for collection.",
+      descriptionStyle: TextStyle(
+        color: Colors.white.withOpacity(0.6),
+        fontSize: 15,
+        fontWeight: FontWeight.w400,
+      ),
+      backgroundColor: Color.fromRGBO(217, 223, 145, 0.09),
+      iconColor: Color(0xFFCDD93C),
+    );
+  }
+}
+
+class TransitLabel extends StatelessWidget {
+  const TransitLabel({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildLabel(
+      title: "Return In Transit",
+      titleStyle: const TextStyle(
+        color: Colors.white,
+        fontSize: 18,
+        fontWeight: FontWeight.w500,
+      ),
+      description:
+          "Your return is on its way back to the seller. The courier has picked up your item, and it is currently in transit.",
+      descriptionStyle: TextStyle(
+        color: Colors.white.withOpacity(0.6),
+        fontSize: 15,
+        fontWeight: FontWeight.w400,
+      ),
+      backgroundColor: Color.fromRGBO(217, 223, 145, 0.09),
+      iconColor: Color(0xFFCDD93C),
+    );
+  }
+}
+
+class ReceivedLabel extends StatelessWidget {
+  const ReceivedLabel({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildLabel(
+      title: "Returned Item(s) Received",
+      titleStyle: const TextStyle(
+        color: Colors.white,
+        fontSize: 18,
+        fontWeight: FontWeight.w500,
+      ),
+      description:
+          "Your returned item has been received by the seller and is now under review. The shop will inspect the item to determine if it meets the return criteria.",
+      descriptionStyle: TextStyle(
+        color: Colors.white.withOpacity(0.6),
+        fontSize: 15,
+        fontWeight: FontWeight.w400,
+      ),
+      backgroundColor: Color.fromRGBO(217, 223, 145, 0.09),
+      iconColor: Color(0xFFCDD93C),
+    );
+  }
+}
+
+class AcceptedLabel extends StatelessWidget {
+  const AcceptedLabel({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildLabel(
+      title: "Return Accepted",
+      titleStyle: const TextStyle(
+        color: Colors.white,
+        fontSize: 18,
+        fontWeight: FontWeight.w500,
+      ),
+      backgroundColor: Color.fromRGBO(217, 223, 145, 0.09),
+      iconColor: Color(0xFFCDD93C),
+      statusIcon: CupertinoIcons.checkmark,
+      statusIconColor: Colors.green,
+    );
+  }
+}
+
+class DeclinedLabel extends StatelessWidget {
+  const DeclinedLabel({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildLabel(
+      title: "Return Declined",
+      titleStyle: const TextStyle(
+        color: Colors.white,
+        fontSize: 18,
+        fontWeight: FontWeight.w500,
+      ),
+      backgroundColor: Color.fromRGBO(217, 223, 145, 0.09),
+      iconColor: Color(0xFFCDD93C),
+      statusIcon: CupertinoIcons.xmark,
+      statusIconColor: Colors.red,
+    );
+  }
+}
+
+Widget _buildLabel({
+  required String title,
+  TextStyle? titleStyle,
+  Widget? subtitle,
+  String? date,
+  TextStyle? dateStyle,
+  String? description,
+  TextStyle? descriptionStyle,
+  required Color backgroundColor,
+  required Color iconColor,
+  IconData? statusIcon,
+  Color? statusIconColor,
+}) {
+  return Container(
+    padding: const EdgeInsets.all(12),
+    margin: const EdgeInsets.symmetric(vertical: 5),
+    decoration: BoxDecoration(
+      color: backgroundColor,
+      borderRadius: BorderRadius.circular(10),
+    ),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                "Order Confirmation",
-                style: TextStyle(fontSize: 18.0),
+                title,
+                style: titleStyle ??
+                    const TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
+                    ),
               ),
+              if (subtitle != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: subtitle,
+                ),
+              if (date != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    date,
+                    style: dateStyle ??
+                        TextStyle(
+                          color: Colors.white.withOpacity(0.8),
+                          fontSize: 14,
+                        ),
+                  ),
+                ),
+              if (description != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    description,
+                    style: descriptionStyle ??
+                        TextStyle(
+                          color: Colors.white.withOpacity(0.6),
+                          fontSize: 13,
+                        ),
+                  ),
+                ),
             ],
           ),
         ),
+        Icon(CupertinoIcons.refresh, color: iconColor),
+        if (statusIcon != null) ...[
+          const SizedBox(width: 6),
+          Icon(statusIcon, color: statusIconColor),
+        ]
       ],
-    );
-  }
+    ),
+  );
 }

--- a/lib/shared/widgets/order_confirmation_view.dart
+++ b/lib/shared/widgets/order_confirmation_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 
 class OrderConfirmationView extends StatelessWidget {
-  const OrderConfirmationView({Key? key}) : super(key: key);
+  const OrderConfirmationView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -11,7 +11,7 @@ class OrderConfirmationView extends StatelessWidget {
 }
 
 class PickupLabel extends StatelessWidget {
-  const PickupLabel({Key? key}) : super(key: key);
+  const PickupLabel({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -59,7 +59,7 @@ class PickupLabel extends StatelessWidget {
 }
 
 class TransitLabel extends StatelessWidget {
-  const TransitLabel({Key? key}) : super(key: key);
+  const TransitLabel({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -84,7 +84,7 @@ class TransitLabel extends StatelessWidget {
 }
 
 class ReceivedLabel extends StatelessWidget {
-  const ReceivedLabel({Key? key}) : super(key: key);
+  const ReceivedLabel({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -109,7 +109,7 @@ class ReceivedLabel extends StatelessWidget {
 }
 
 class AcceptedLabel extends StatelessWidget {
-  const AcceptedLabel({Key? key}) : super(key: key);
+  const AcceptedLabel({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -129,7 +129,7 @@ class AcceptedLabel extends StatelessWidget {
 }
 
 class DeclinedLabel extends StatelessWidget {
-  const DeclinedLabel({Key? key}) : super(key: key);
+  const DeclinedLabel({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
<!-- This PR introduces the initial database configuration for the project. -->
### Implement Return Status Labels for Different Return Stages

<!-- Examples for Description: The project uses `Spring Data JPA` for database access and management, and is configured with `PostgreSQL` as the database type. This setup includes the necessary connection settings and PostgreSQL driver dependencies to establish connectivity. -->
#### 📌 Description
> This pull request introduces a suite of Return Status Label components, designed to provide users with clear, consistent, and intuitive visual feedback on the progress of their return requests. These reusable labels help standardize status indication across the return process, improving transparency and reducing confusion for end users. With these labels, users can instantly identify the current state of their return.

<!-- list of features created and not created -->
#### 📒 Summary of Changes
- [X] Built Reusable Return Status Labels - Developed a set of flexible React components that serve as the foundation for rendering various return statuses. These components are styled for clarity and optimized for reusability across different parts of the application.
- [X] Implemented PickupLabel – Indicates Scheduled Pickup
- [X] Implemented TransitLabel – Indicates Item in Transit
- [X] Implemented ReceivedLabel – Indicates Return Received by Seller
- [X] Implemented AcceptedLabel – Indicates Return Has Been Approved
- [X] Implemented DeclinedLabel – Indicates Return Has Been Rejected
- [ ] Accessibility Enhancements – Ensure all labels meet accessibility standards
- [ ] Add Label Animations or Transitions – To improve UX by adding smooth state changes between return stages.

<br>
<details>
<summary><b>📱 View Screenshots</b></summary>
<br>

| Return Status Labels (Pickup, Transit, Received, Accepted, Declined)  |   
|--------------------------------|
|![return labels](https://github.com/user-attachments/assets/a2d9f74b-68c4-48a5-ab10-953d727243df)
                  


<!-- Replace table with image links of the screenshots -->
